### PR TITLE
Report component status on connection

### DIFF
--- a/src/operator/controllers/otterizeclient/status_report.go
+++ b/src/operator/controllers/otterizeclient/status_report.go
@@ -23,6 +23,8 @@ func runPeriodicReportConnection(interval int, client *CloudClient) {
 	cloudUploadTicker := time.NewTicker(time.Second * time.Duration(interval))
 
 	logrus.Info("Starting cloud connection ticker")
+	client.ReportComponentStatus(ctx)
+
 	for {
 		select {
 		case <-cloudUploadTicker.C:


### PR DESCRIPTION
To make the component appear as connected right when it is up, this PR send the connection right when operator is up, since there is no reason to wait.