### PR TITLE
Implement CleanupOrphanK8SPodEntries on Otterize's CloudClient

### DIFF
--- a/src/operator/controllers/otterizeclient/client.go
+++ b/src/operator/controllers/otterizeclient/client.go
@@ -76,7 +76,7 @@ func (c *CloudClient) CleanupOrphanK8SPodEntries(ctx context.Context, _ string, 
 			namespacedPodOwners = append(namespacedPodOwners, otterizegraphql.NamespacedPodOwner{Namespace: namespace, Name: podOwner})
 		}
 	}
-	res, err := otterizegraphql.CleanupOrphanK8SPodEntries(ctx, c.graphqlClient, namespacedPodOwners)
+	res, err := otterizegraphql.ReportActiveCertificateRequesters(ctx, c.graphqlClient, namespacedPodOwners)
 	if err != nil {
 		return fmt.Errorf("failed removing orphan entries: %w", err)
 	}

--- a/src/operator/controllers/otterizeclient/client.go
+++ b/src/operator/controllers/otterizeclient/client.go
@@ -69,7 +69,21 @@ func (c *CloudClient) RegisterK8SPod(ctx context.Context, namespace string, _ st
 	return res.RegisterKubernetesPodOwnerCertificateRequest.Id, nil
 }
 
-func (c *CloudClient) CleanupOrphanK8SPodEntries(_ context.Context, _ string, _ map[string]*goset.Set[string]) error {
+func (c *CloudClient) CleanupOrphanK8SPodEntries(ctx context.Context, _ string, existingServicesByNamespace map[string]*goset.Set[string]) error {
+	var namespacedPodOwners []otterizegraphql.NamespacedPodOwner
+	for namespace, podOwnerNames := range existingServicesByNamespace {
+		for _, podOwner := range podOwnerNames.Items() {
+			namespacedPodOwners = append(namespacedPodOwners, otterizegraphql.NamespacedPodOwner{Namespace: namespace, Name: podOwner})
+		}
+	}
+	res, err := otterizegraphql.CleanupOrphanK8SPodEntries(ctx, c.graphqlClient, namespacedPodOwners)
+	if err != nil {
+		return fmt.Errorf("failed removing orphan entries: %w", err)
+	}
+	if !res.RemoveOrphanedCertificateRequests {
+		return fmt.Errorf("failed removing orphan entries")
+	}
+
 	return nil
 }
 

--- a/src/operator/controllers/otterizeclient/client.go
+++ b/src/operator/controllers/otterizeclient/client.go
@@ -80,7 +80,7 @@ func (c *CloudClient) CleanupOrphanK8SPodEntries(ctx context.Context, _ string, 
 	if err != nil {
 		return fmt.Errorf("failed removing orphan entries: %w", err)
 	}
-	if !res.RemoveOrphanedCertificateRequests {
+	if !res.ReportActiveCertificateRequesters {
 		return fmt.Errorf("failed removing orphan entries")
 	}
 

--- a/src/operator/controllers/otterizeclient/otterizegraphql/generated.go
+++ b/src/operator/controllers/otterizeclient/otterizegraphql/generated.go
@@ -23,12 +23,12 @@ func (v *CertificateCustomization) GetTtl() int { return v.Ttl }
 // CleanupOrphanK8SPodEntriesResponse is returned by CleanupOrphanK8SPodEntries on success.
 type CleanupOrphanK8SPodEntriesResponse struct {
 	// Removes certificateRequests of pod owners from the context's cluster which does not appear in the "activePodOwners" list
-	RemoveOrphanedCertificateRequests bool `json:"removeOrphanedCertificateRequests"`
+	ReportActiveCertificateRequesters bool `json:"reportActiveCertificateRequesters"`
 }
 
-// GetRemoveOrphanedCertificateRequests returns CleanupOrphanK8SPodEntriesResponse.RemoveOrphanedCertificateRequests, and is useful for accessing the field via an interface.
-func (v *CleanupOrphanK8SPodEntriesResponse) GetRemoveOrphanedCertificateRequests() bool {
-	return v.RemoveOrphanedCertificateRequests
+// GetReportActiveCertificateRequesters returns CleanupOrphanK8SPodEntriesResponse.ReportActiveCertificateRequesters, and is useful for accessing the field via an interface.
+func (v *CleanupOrphanK8SPodEntriesResponse) GetReportActiveCertificateRequesters() bool {
+	return v.ReportActiveCertificateRequesters
 }
 
 type ComponentType string
@@ -255,7 +255,7 @@ func CleanupOrphanK8SPodEntries(
 		OpName: "CleanupOrphanK8SPodEntries",
 		Query: `
 mutation CleanupOrphanK8SPodEntries ($existingPodOwners: [NamespacedPodOwner!]!) {
-	removeOrphanedCertificateRequests(activePodOwners: $existingPodOwners)
+	reportActiveCertificateRequesters(activePodOwners: $existingPodOwners)
 }
 `,
 		Variables: &__CleanupOrphanK8SPodEntriesInput{
@@ -328,7 +328,7 @@ func RegisterKubernetesPodOwnerCertificateRequest(
 		OpName: "RegisterKubernetesPodOwnerCertificateRequest",
 		Query: `
 mutation RegisterKubernetesPodOwnerCertificateRequest ($namespace: String!, $podOwnerName: String!, $certificateCustomizations: CertificateCustomization) {
-	registerKubernetesPodOwnerCertificateRequest(namespace: $namespace, podOwnerName: $podOwnerName, certificateCustomization: $certificateCustomizations) {
+	registerKubernetesPodOwnerCertificateRequest(podOwner: {name:$podOwnerName,namespace:$namespace}, certificateCustomization: $certificateCustomizations) {
 		id
 	}
 }

--- a/src/operator/controllers/otterizeclient/otterizegraphql/generated.go
+++ b/src/operator/controllers/otterizeclient/otterizegraphql/generated.go
@@ -20,17 +20,6 @@ func (v *CertificateCustomization) GetDnsNames() []string { return v.DnsNames }
 // GetTtl returns CertificateCustomization.Ttl, and is useful for accessing the field via an interface.
 func (v *CertificateCustomization) GetTtl() int { return v.Ttl }
 
-// CleanupOrphanK8SPodEntriesResponse is returned by CleanupOrphanK8SPodEntries on success.
-type CleanupOrphanK8SPodEntriesResponse struct {
-	// Removes certificateRequests of pod owners from the context's cluster which does not appear in the "activePodOwners" list
-	ReportActiveCertificateRequesters bool `json:"reportActiveCertificateRequesters"`
-}
-
-// GetReportActiveCertificateRequesters returns CleanupOrphanK8SPodEntriesResponse.ReportActiveCertificateRequesters, and is useful for accessing the field via an interface.
-func (v *CleanupOrphanK8SPodEntriesResponse) GetReportActiveCertificateRequesters() bool {
-	return v.ReportActiveCertificateRequesters
-}
-
 type ComponentType string
 
 const (
@@ -164,6 +153,17 @@ func (v *RegisterKubernetesPodOwnerCertificateRequestResponse) GetRegisterKubern
 	return v.RegisterKubernetesPodOwnerCertificateRequest
 }
 
+// ReportActiveCertificateRequestersResponse is returned by ReportActiveCertificateRequesters on success.
+type ReportActiveCertificateRequestersResponse struct {
+	// Report active pod owners to the cloud, as a result the cloud removes certificate requests of inactive pod owners
+	ReportActiveCertificateRequesters bool `json:"reportActiveCertificateRequesters"`
+}
+
+// GetReportActiveCertificateRequesters returns ReportActiveCertificateRequestersResponse.ReportActiveCertificateRequesters, and is useful for accessing the field via an interface.
+func (v *ReportActiveCertificateRequestersResponse) GetReportActiveCertificateRequesters() bool {
+	return v.ReportActiveCertificateRequesters
+}
+
 // ReportComponentStatusResponse is returned by ReportComponentStatus on success.
 type ReportComponentStatusResponse struct {
 	ReportIntegrationComponentStatus bool `json:"reportIntegrationComponentStatus"`
@@ -198,16 +198,6 @@ func (v *TLSKeyPair) GetRootCAPEM() string { return v.RootCAPEM }
 // GetExpiresAt returns TLSKeyPair.ExpiresAt, and is useful for accessing the field via an interface.
 func (v *TLSKeyPair) GetExpiresAt() int { return v.ExpiresAt }
 
-// __CleanupOrphanK8SPodEntriesInput is used internally by genqlient
-type __CleanupOrphanK8SPodEntriesInput struct {
-	ExistingPodOwners []NamespacedPodOwner `json:"existingPodOwners"`
-}
-
-// GetExistingPodOwners returns __CleanupOrphanK8SPodEntriesInput.ExistingPodOwners, and is useful for accessing the field via an interface.
-func (v *__CleanupOrphanK8SPodEntriesInput) GetExistingPodOwners() []NamespacedPodOwner {
-	return v.ExistingPodOwners
-}
-
 // __GetTLSKeyPairInput is used internally by genqlient
 type __GetTLSKeyPairInput struct {
 	Id *string `json:"id"`
@@ -238,6 +228,16 @@ func (v *__RegisterKubernetesPodOwnerCertificateRequestInput) GetCertificateCust
 	return v.CertificateCustomizations
 }
 
+// __ReportActiveCertificateRequestersInput is used internally by genqlient
+type __ReportActiveCertificateRequestersInput struct {
+	ExistingPodOwners []NamespacedPodOwner `json:"existingPodOwners"`
+}
+
+// GetExistingPodOwners returns __ReportActiveCertificateRequestersInput.ExistingPodOwners, and is useful for accessing the field via an interface.
+func (v *__ReportActiveCertificateRequestersInput) GetExistingPodOwners() []NamespacedPodOwner {
+	return v.ExistingPodOwners
+}
+
 // __ReportComponentStatusInput is used internally by genqlient
 type __ReportComponentStatusInput struct {
 	Component ComponentType `json:"component"`
@@ -245,36 +245,6 @@ type __ReportComponentStatusInput struct {
 
 // GetComponent returns __ReportComponentStatusInput.Component, and is useful for accessing the field via an interface.
 func (v *__ReportComponentStatusInput) GetComponent() ComponentType { return v.Component }
-
-func CleanupOrphanK8SPodEntries(
-	ctx context.Context,
-	client graphql.Client,
-	existingPodOwners []NamespacedPodOwner,
-) (*CleanupOrphanK8SPodEntriesResponse, error) {
-	req := &graphql.Request{
-		OpName: "CleanupOrphanK8SPodEntries",
-		Query: `
-mutation CleanupOrphanK8SPodEntries ($existingPodOwners: [NamespacedPodOwner!]!) {
-	reportActiveCertificateRequesters(activePodOwners: $existingPodOwners)
-}
-`,
-		Variables: &__CleanupOrphanK8SPodEntriesInput{
-			ExistingPodOwners: existingPodOwners,
-		},
-	}
-	var err error
-
-	var data CleanupOrphanK8SPodEntriesResponse
-	resp := &graphql.Response{Data: &data}
-
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
-	)
-
-	return &data, err
-}
 
 func GetTLSKeyPair(
 	ctx context.Context,
@@ -342,6 +312,36 @@ mutation RegisterKubernetesPodOwnerCertificateRequest ($namespace: String!, $pod
 	var err error
 
 	var data RegisterKubernetesPodOwnerCertificateRequestResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+func ReportActiveCertificateRequesters(
+	ctx context.Context,
+	client graphql.Client,
+	existingPodOwners []NamespacedPodOwner,
+) (*ReportActiveCertificateRequestersResponse, error) {
+	req := &graphql.Request{
+		OpName: "ReportActiveCertificateRequesters",
+		Query: `
+mutation ReportActiveCertificateRequesters ($existingPodOwners: [NamespacedPodOwner!]!) {
+	reportActiveCertificateRequesters(activePodOwners: $existingPodOwners)
+}
+`,
+		Variables: &__ReportActiveCertificateRequestersInput{
+			ExistingPodOwners: existingPodOwners,
+		},
+	}
+	var err error
+
+	var data ReportActiveCertificateRequestersResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/src/operator/controllers/otterizeclient/otterizegraphql/generated.go
+++ b/src/operator/controllers/otterizeclient/otterizegraphql/generated.go
@@ -20,6 +20,17 @@ func (v *CertificateCustomization) GetDnsNames() []string { return v.DnsNames }
 // GetTtl returns CertificateCustomization.Ttl, and is useful for accessing the field via an interface.
 func (v *CertificateCustomization) GetTtl() int { return v.Ttl }
 
+// CleanupOrphanK8SPodEntriesResponse is returned by CleanupOrphanK8SPodEntries on success.
+type CleanupOrphanK8SPodEntriesResponse struct {
+	// Removes certificateRequests of pod owners from the context's cluster which does not appear in the "activePodOwners" list
+	RemoveOrphanedCertificateRequests bool `json:"removeOrphanedCertificateRequests"`
+}
+
+// GetRemoveOrphanedCertificateRequests returns CleanupOrphanK8SPodEntriesResponse.RemoveOrphanedCertificateRequests, and is useful for accessing the field via an interface.
+func (v *CleanupOrphanK8SPodEntriesResponse) GetRemoveOrphanedCertificateRequests() bool {
+	return v.RemoveOrphanedCertificateRequests
+}
+
 type ComponentType string
 
 const (
@@ -121,6 +132,17 @@ func (v *GetTLSKeyPairServiceTlsKeyPair) __premarshalJSON() (*__premarshalGetTLS
 	return &retval, nil
 }
 
+type NamespacedPodOwner struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+// GetName returns NamespacedPodOwner.Name, and is useful for accessing the field via an interface.
+func (v *NamespacedPodOwner) GetName() string { return v.Name }
+
+// GetNamespace returns NamespacedPodOwner.Namespace, and is useful for accessing the field via an interface.
+func (v *NamespacedPodOwner) GetNamespace() string { return v.Namespace }
+
 // RegisterKubernetesPodOwnerCertificateRequestRegisterKubernetesPodOwnerCertificateRequestService includes the requested fields of the GraphQL type Service.
 type RegisterKubernetesPodOwnerCertificateRequestRegisterKubernetesPodOwnerCertificateRequestService struct {
 	Id string `json:"id"`
@@ -176,6 +198,16 @@ func (v *TLSKeyPair) GetRootCAPEM() string { return v.RootCAPEM }
 // GetExpiresAt returns TLSKeyPair.ExpiresAt, and is useful for accessing the field via an interface.
 func (v *TLSKeyPair) GetExpiresAt() int { return v.ExpiresAt }
 
+// __CleanupOrphanK8SPodEntriesInput is used internally by genqlient
+type __CleanupOrphanK8SPodEntriesInput struct {
+	ExistingPodOwners []NamespacedPodOwner `json:"existingPodOwners"`
+}
+
+// GetExistingPodOwners returns __CleanupOrphanK8SPodEntriesInput.ExistingPodOwners, and is useful for accessing the field via an interface.
+func (v *__CleanupOrphanK8SPodEntriesInput) GetExistingPodOwners() []NamespacedPodOwner {
+	return v.ExistingPodOwners
+}
+
 // __GetTLSKeyPairInput is used internally by genqlient
 type __GetTLSKeyPairInput struct {
 	Id *string `json:"id"`
@@ -213,6 +245,36 @@ type __ReportComponentStatusInput struct {
 
 // GetComponent returns __ReportComponentStatusInput.Component, and is useful for accessing the field via an interface.
 func (v *__ReportComponentStatusInput) GetComponent() ComponentType { return v.Component }
+
+func CleanupOrphanK8SPodEntries(
+	ctx context.Context,
+	client graphql.Client,
+	existingPodOwners []NamespacedPodOwner,
+) (*CleanupOrphanK8SPodEntriesResponse, error) {
+	req := &graphql.Request{
+		OpName: "CleanupOrphanK8SPodEntries",
+		Query: `
+mutation CleanupOrphanK8SPodEntries ($existingPodOwners: [NamespacedPodOwner!]!) {
+	removeOrphanedCertificateRequests(activePodOwners: $existingPodOwners)
+}
+`,
+		Variables: &__CleanupOrphanK8SPodEntriesInput{
+			ExistingPodOwners: existingPodOwners,
+		},
+	}
+	var err error
+
+	var data CleanupOrphanK8SPodEntriesResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
 
 func GetTLSKeyPair(
 	ctx context.Context,

--- a/src/operator/controllers/otterizeclient/otterizegraphql/genqlient.graphql
+++ b/src/operator/controllers/otterizeclient/otterizegraphql/genqlient.graphql
@@ -26,6 +26,6 @@ mutation ReportComponentStatus($component: ComponentType!) {
     reportIntegrationComponentStatus(component: $component)
 }
 
-mutation CleanupOrphanK8SPodEntries($existingPodOwners: [NamespacedPodOwner!]!) {
+mutation ReportActiveCertificateRequesters($existingPodOwners: [NamespacedPodOwner!]!) {
     reportActiveCertificateRequesters(activePodOwners: $existingPodOwners)
 }

--- a/src/operator/controllers/otterizeclient/otterizegraphql/genqlient.graphql
+++ b/src/operator/controllers/otterizeclient/otterizegraphql/genqlient.graphql
@@ -7,7 +7,7 @@ fragment TLSKeyPair on KeyPair {
 }
 
 mutation RegisterKubernetesPodOwnerCertificateRequest($namespace: String!, $podOwnerName: String!, $certificateCustomizations: CertificateCustomization) {
-    registerKubernetesPodOwnerCertificateRequest(namespace: $namespace, podOwnerName: $podOwnerName, certificateCustomization: $certificateCustomizations)
+    registerKubernetesPodOwnerCertificateRequest(podOwner: {name: $podOwnerName, namespace: $namespace}, certificateCustomization: $certificateCustomizations)
     {
         id
     }
@@ -27,5 +27,5 @@ mutation ReportComponentStatus($component: ComponentType!) {
 }
 
 mutation CleanupOrphanK8SPodEntries($existingPodOwners: [NamespacedPodOwner!]!) {
-    removeOrphanedCertificateRequests(activePodOwners: $existingPodOwners)
+    reportActiveCertificateRequesters(activePodOwners: $existingPodOwners)
 }

--- a/src/operator/controllers/otterizeclient/otterizegraphql/genqlient.graphql
+++ b/src/operator/controllers/otterizeclient/otterizegraphql/genqlient.graphql
@@ -25,3 +25,7 @@ query GetTLSKeyPair ($id: ID!) {
 mutation ReportComponentStatus($component: ComponentType!) {
     reportIntegrationComponentStatus(component: $component)
 }
+
+mutation CleanupOrphanK8SPodEntries($existingPodOwners: [NamespacedPodOwner!]!) {
+    removeOrphanedCertificateRequests(activePodOwners: $existingPodOwners)
+}


### PR DESCRIPTION

### Description

Use otterize-cloud's RemoveOrphanedCertificateRequests for implementing CleanupOrphanK8SPodEntries on Otterize's CloudClient

### Testing

No test because it is just an implementation of the interface. (tested on the cloud side)
