### PR TITLE
Add the option to register only pods with secret annotations

### DIFF
--- a/src/operator/controllers/pod_controller.go
+++ b/src/operator/controllers/pod_controller.go
@@ -175,8 +175,6 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	shouldCreateSecret := r.shouldCreateSecretPod(pod)
-
 	if !r.shouldRegisterEntryForPod(pod) {
 		return ctrl.Result{}, nil
 	}
@@ -230,7 +228,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	shouldRestartPodOnRenewal := r.resolvePodToShouldRestartOnRenewal(pod)
 
-	if !shouldCreateSecret {
+	if !r.shouldCreateSecretForPod(pod) {
 		log.WithField("annotation.key", metadata.TLSSecretNameAnnotation).Info("skipping TLS secrets creation - annotation not found")
 		return ctrl.Result{}, err
 	}
@@ -281,12 +279,12 @@ func (r *PodReconciler) resolvePodToCertTTl(pod *corev1.Pod) (int32, error) {
 	return int32(ttl64), nil
 }
 
-func (r *PodReconciler) shouldCreateSecretPod(pod *corev1.Pod) bool {
+func (r *PodReconciler) shouldCreateSecretForPod(pod *corev1.Pod) bool {
 	return pod.Annotations != nil && pod.Annotations[metadata.TLSSecretNameAnnotation] != ""
 }
 
 func (r *PodReconciler) shouldRegisterEntryForPod(pod *corev1.Pod) bool {
-	return !r.registerOnlyPodsWithSecretAnnotation || r.shouldCreateSecretPod(pod)
+	return !r.registerOnlyPodsWithSecretAnnotation || r.shouldCreateSecretForPod(pod)
 }
 
 func (r *PodReconciler) resolvePodToShouldRestartOnRenewal(pod *corev1.Pod) bool {

--- a/src/operator/controllers/pod_controller.go
+++ b/src/operator/controllers/pod_controller.go
@@ -23,17 +23,17 @@ import (
 )
 
 const (
-	refreshSecretsLoopTick                = time.Minute
-	cleanupOrphanEntriesLoopTick          = 10 * time.Minute
-	ReasonEnsuredPodTLS                   = "EnsuredPodTLS"
-	ReasonEnsuringPodTLSFailed            = "EnsuringPodTLSFailed"
-	ReasonPodOwnerResolutionFailed        = "PodOwnerResolutionFailed"
-	ReasonPodLabelUpdateFailed            = "PodLabelUpdateFailed"
-	ReasonCertDNSResolutionFailed         = "CertDNSResolutionFailed"
-	ReasonCertTTLError                    = "CertTTLError"
-	ReasonSPIREEntryRegistrationFailed    = "SPIREEntryRegistrationFailed"
-	ReasonPodRegistered                   = "PodRegistered"
-	ReasonSPIREEntryHashCalculationFailed = "SPIREEntryHashCalculationFailed"
+	refreshSecretsLoopTick           = time.Minute
+	cleanupOrphanEntriesLoopTick     = 10 * time.Minute
+	ReasonEnsuredPodTLS              = "EnsuredPodTLS"
+	ReasonEnsuringPodTLSFailed       = "EnsuringPodTLSFailed"
+	ReasonPodOwnerResolutionFailed   = "PodOwnerResolutionFailed"
+	ReasonPodLabelUpdateFailed       = "PodLabelUpdateFailed"
+	ReasonCertDNSResolutionFailed    = "CertDNSResolutionFailed"
+	ReasonCertTTLError               = "CertTTLError"
+	ReasonEntryRegistrationFailed    = "EntryRegistrationFailed"
+	ReasonPodRegistered              = "PodRegistered"
+	ReasonEntryHashCalculationFailed = "EntryHashCalculationFailed"
 )
 
 type WorkloadRegistry interface {
@@ -49,11 +49,12 @@ type SecretsManager interface {
 // PodReconciler reconciles a Pod object
 type PodReconciler struct {
 	client.Client
-	scheme            *runtime.Scheme
-	workloadRegistry  WorkloadRegistry
-	secretsManager    SecretsManager
-	serviceIdResolver *serviceidresolver.Resolver
-	eventRecorder     record.EventRecorder
+	scheme                               *runtime.Scheme
+	workloadRegistry                     WorkloadRegistry
+	secretsManager                       SecretsManager
+	serviceIdResolver                    *serviceidresolver.Resolver
+	eventRecorder                        record.EventRecorder
+	registerOnlyPodsWithSecretAnnotation bool
 }
 
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;update;patch
@@ -62,14 +63,16 @@ type PodReconciler struct {
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;update;patch;list;watch;create
 
 func NewPodReconciler(client client.Client, scheme *runtime.Scheme, workloadRegistry WorkloadRegistry,
-	secretsManager SecretsManager, serviceIdResolver *serviceidresolver.Resolver, eventRecorder record.EventRecorder) *PodReconciler {
+	secretsManager SecretsManager, serviceIdResolver *serviceidresolver.Resolver, eventRecorder record.EventRecorder,
+	registerOnlyPodsWithSecretAnnotation bool) *PodReconciler {
 	return &PodReconciler{
-		Client:            client,
-		scheme:            scheme,
-		workloadRegistry:  workloadRegistry,
-		secretsManager:    secretsManager,
-		serviceIdResolver: serviceIdResolver,
-		eventRecorder:     eventRecorder,
+		Client:                               client,
+		scheme:                               scheme,
+		workloadRegistry:                     workloadRegistry,
+		secretsManager:                       secretsManager,
+		serviceIdResolver:                    serviceIdResolver,
+		eventRecorder:                        eventRecorder,
+		registerOnlyPodsWithSecretAnnotation: registerOnlyPodsWithSecretAnnotation,
 	}
 }
 
@@ -109,11 +112,6 @@ func (r *PodReconciler) updatePodLabel(ctx context.Context, pod *corev1.Pod, lab
 
 func (r *PodReconciler) ensurePodTLSSecret(ctx context.Context, pod *corev1.Pod, serviceName string, entryID string, entryHash string, shouldRestartPodOnRenewal bool) error {
 	log := logrus.WithFields(logrus.Fields{"pod": pod.Name, "namespace": pod.Namespace})
-	if pod.Annotations == nil || pod.Annotations[metadata.TLSSecretNameAnnotation] == "" {
-		log.WithField("annotation.key", metadata.TLSSecretNameAnnotation).Info("skipping TLS secrets creation - annotation not found")
-		return nil
-	}
-
 	secretName := pod.Annotations[metadata.TLSSecretNameAnnotation]
 	certConfig, err := certConfigFromPod(pod)
 	if err != nil {
@@ -172,6 +170,17 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, err
 	}
 
+	// nothing to reconcile on deletions
+	if !pod.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	shouldCreateSecret := r.shouldCreateSecretPod(pod)
+
+	if !r.shouldRegisterEntryForPod(pod) {
+		return ctrl.Result{}, nil
+	}
+
 	log.Info("updating workload entries & secrets for pod")
 
 	// resolve pod to otterize service name
@@ -208,19 +217,23 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	entryID, err := r.workloadRegistry.RegisterK8SPod(ctx, pod.Namespace, metadata.RegisteredServiceNameLabel, serviceID, ttl, dnsNames)
 	if err != nil {
 		log.WithError(err).Error("failed registering workload entry for pod")
-		r.eventRecorder.Eventf(pod, corev1.EventTypeWarning, ReasonSPIREEntryRegistrationFailed, "Failed registering workload entry: %s", err.Error())
+		r.eventRecorder.Eventf(pod, corev1.EventTypeWarning, ReasonEntryRegistrationFailed, "Failed registering workload entry: %s", err.Error())
 		return ctrl.Result{}, err
 	}
 	r.eventRecorder.Eventf(pod, corev1.EventTypeNormal, ReasonPodRegistered, "Successfully registered pod under workload with entry ID '%s'", entryID)
 
 	hashStr, err := getEntryHash(pod.Namespace, serviceID, ttl, dnsNames)
 	if err != nil {
-		r.eventRecorder.Eventf(pod, corev1.EventTypeWarning, ReasonSPIREEntryHashCalculationFailed, "Failed calculating workload entry hash: %s", err.Error())
+		r.eventRecorder.Eventf(pod, corev1.EventTypeWarning, ReasonEntryHashCalculationFailed, "Failed calculating workload entry hash: %s", err.Error())
 		return ctrl.Result{}, err
 	}
 
 	shouldRestartPodOnRenewal := r.resolvePodToShouldRestartOnRenewal(pod)
 
+	if !shouldCreateSecret {
+		log.WithField("annotation.key", metadata.TLSSecretNameAnnotation).Info("skipping TLS secrets creation - annotation not found")
+		return ctrl.Result{}, err
+	}
 	// generate TLS secret for pod
 	if err := r.ensurePodTLSSecret(ctx, pod, serviceID, entryID, hashStr, shouldRestartPodOnRenewal); err != nil {
 		r.eventRecorder.Eventf(pod, corev1.EventTypeWarning, ReasonEnsuringPodTLSFailed, "Failed creating TLS secret for pod: %s", err.Error())
@@ -268,6 +281,14 @@ func (r *PodReconciler) resolvePodToCertTTl(pod *corev1.Pod) (int32, error) {
 	return int32(ttl64), nil
 }
 
+func (r *PodReconciler) shouldCreateSecretPod(pod *corev1.Pod) bool {
+	return pod.Annotations != nil && pod.Annotations[metadata.TLSSecretNameAnnotation] != ""
+}
+
+func (r *PodReconciler) shouldRegisterEntryForPod(pod *corev1.Pod) bool {
+	return !r.registerOnlyPodsWithSecretAnnotation || r.shouldCreateSecretPod(pod)
+}
+
 func (r *PodReconciler) resolvePodToShouldRestartOnRenewal(pod *corev1.Pod) bool {
 	_, ok := pod.Annotations[metadata.ShouldRestartOnRenewalAnnotation]
 	return ok
@@ -292,7 +313,9 @@ func (r *PodReconciler) cleanupOrphanEntries(ctx context.Context) error {
 			existingServicesByNamespace[pod.Namespace] = goset.NewSet[string]()
 		}
 
-		existingServicesByNamespace[pod.Namespace].Add(pod.Labels[metadata.RegisteredServiceNameLabel])
+		if r.shouldRegisterEntryForPod(&pod) {
+			existingServicesByNamespace[pod.Namespace].Add(pod.Labels[metadata.RegisteredServiceNameLabel])
+		}
 	}
 
 	if err := r.workloadRegistry.CleanupOrphanK8SPodEntries(ctx, metadata.RegisteredServiceNameLabel, existingServicesByNamespace); err != nil {
@@ -320,6 +343,7 @@ func (r *PodReconciler) MaintenanceLoop(ctx context.Context) {
 				if err != nil {
 					logrus.WithError(err).Error("failed cleaning up orphan SPIRE entries")
 				}
+				logrus.Info("successfully cleaned up entries of inactive pods")
 			}()
 		case <-ctx.Done():
 			return

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -138,7 +138,7 @@ func main() {
 	}
 
 	podReconciler := controllers.NewPodReconciler(mgr.GetClient(), mgr.GetScheme(), workloadRegistry, secretsManager,
-		serviceIdResolver, eventRecorder)
+		serviceIdResolver, eventRecorder, useOtterizeCloud)
 
 	if err = podReconciler.SetupWithManager(mgr); err != nil {
 		logrus.WithField("controller", "Pod").WithError(err).Error("unable to create controller")


### PR DESCRIPTION

### Description

For otterize-cloud integration - add the option of not register every pod but only those which ask for a secret


### Testing

added a test for r`egisterOnlyPodsWithSecretAnnotation=true`
