### PR TITLE
Publish docker image to credentials-operator instead of spire-integration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,7 +77,7 @@ jobs:
         with:
           context: src/operator
           file: src/operator/Dockerfile
-          tags: ${{ env.REGISTRY }}:spire-integration-operator-${{ github.sha }}
+          tags: ${{ env.REGISTRY }}:credentials-operator-${{ github.sha }}
           push: true
           network: host
           cache-from: type=gha
@@ -113,4 +113,4 @@ jobs:
       - name: Tag Images as latest
         run: |-
           retag_image_as_latest() { MANIFEST=$(aws ecr batch-get-image --repository-name ${{ env.REPOSITORY_NAME }} --image-ids imageTag="$1-${{ github.sha }}" --query "images[].imageManifest" --output text); if [ -z "$MANIFEST" ]; then echo Manifest not found; exit 1; fi; OUTPUT=$(aws ecr put-image --repository-name ${{ env.REPOSITORY_NAME }} --image-tag "$1-latest" --image-manifest "$MANIFEST" 2>&1 || true); if echo $OUTPUT | grep 'An error occurred' >/dev/null && ! echo $OUTPUT | grep ImageAlreadyExistsException >/dev/null; then echo $OUTPUT; exit 1; fi; }
-          retag_image_as_latest spire-integration-operator
+          retag_image_as_latest credentials-operator

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Push to Docker Hub
         run: |-
-          docker pull ${{ env.REGISTRY }}:spire-integration-operator-${{ github.sha }}
-          docker tag ${{ env.REGISTRY }}:spire-integration-operator-${{ github.sha }} otterize/spire-integration-operator:${{ github.ref_name }}
-          docker tag ${{ env.REGISTRY }}:spire-integration-operator-${{ github.sha }} otterize/spire-integration-operator:latest
-          docker push otterize/spire-integration-operator:${{ github.ref_name }}
-          docker push otterize/spire-integration-operator:latest
+          docker pull ${{ env.REGISTRY }}:credentials-operator-${{ github.sha }}
+          docker tag ${{ env.REGISTRY }}:credentials-operator-${{ github.sha }} otterize/spire-integration-operator:${{ github.ref_name }}
+          docker tag ${{ env.REGISTRY }}:credentials-operator-${{ github.sha }} otterize/spire-integration-operator:latest
+          docker push otterize/credentials-operator:${{ github.ref_name }}
+          docker push otterize/credentials-operator:latest


### PR DESCRIPTION

### Description

Publish the docker image to credentials-operator instead of spire-integration. 

